### PR TITLE
Add Gforth (Forth) implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ AI platforms that have helped with any code in this repo include:
   - `Grok Code Fast 1`
 - [LocalAI](https://localai.io/) using:
   - `gpt-oss-120b`
+- [Claude Code](https://claude.ai/code) using:
+  - `Claude Sonnet 4.6`
 
 
 In February 15, 2026, I used GitHub Copilot, which at this moment used `Claude Haiku 4.5`, to do some long-deferred maintenance. I always intended to use the same variable names across all files and, at least as much as possible, the same game logic. But, I had let some inconsistencies creep in and it got worse over time as I didn't always use the same existing language version as my template while creating a new language implementation. I thought it would be a useful test of AI effectiveness while accomplishing something I wanted, so I collaborated with the AI agent to standardize and test every current implementation and generated a [Test Report here](./TEST_REPORT.md). I'm deeply impressed today!
@@ -72,6 +74,7 @@ The same game is currently implemented in the following languages:
 - BASIC                                                 (`guessnumber.bas`)
 - C                                                     (`guessnumber.c`)
 - COBOL                                                 (`guessnumber.cob`)
+- Forth using Gforth                                    (`guessnumber.fth`)
 - Fortran                                               (`guessnumber.f90`)
 - Go                                                    (`guessnumber.go`)
 - Java                                                  (`guessnumber.java`)
@@ -89,9 +92,27 @@ The same game is currently implemented in the following languages:
 Each version lives as a self-contained program and can be run independently using the tooling idiomatic to that language. See the comments at the start of each file for language-specific details.
 
 
+## Variable naming convention
+
+All implementations use the same variable names wherever the concept appears, to make side-by-side comparison easier, especially for students.
+
+| Variable | Purpose |
+|---|---|
+| `secretnumber` | the randomly chosen target number |
+| `userguess` | the user's validated guess |
+| `userguessunvalidated` | raw user input before validation |
+| `totalguesses` | shared counter, incremented for every guess (user or computer) |
+| `lowmax` | current lower bound (starts at 1) |
+| `highmax` | current upper bound (starts at 100) |
+| `guessrange` | `highmax - lowmax` (guards against a zero-range edge case) |
+| `computerguess` | the computer's midpoint calculation |
+
+Some languages express these differently — Forth, for example, uses named memory locations rather than typed variables — but the names are preserved regardless.
+
+
 ## Extra notes on a couple of languages
 
-Rust and R get notes not because they are special, but because they required *documented tradeoffs* that future readers might otherwise misinterpret as mistakes.
+Forth, R, and Rust get notes not because they are special, but because they required *documented tradeoffs* that future readers might otherwise misinterpret as mistakes.
 
 ### R
 
@@ -106,6 +127,16 @@ When running under Rscript, `readline()` does not reliably block for user input 
 `readLines("stdin", n = 1)`
 
 wrapped in a small helper function to ensure correct blocking behavior, EOF detection, and portability. This choice is deliberate and documented in the source to save future readers from rediscovering the issue.
+
+
+### Forth (Gforth)
+
+Standard ANS Forth has no built-in random number facility. The Forth version targets **Gforth** (GNU Forth) and uses two Gforth-specific features not present in all Forth systems:
+
+- `require random.fs` loads Gforth's bundled linear congruential RNG, which provides the `random` word (`n -- 0..n-1`) and a `seed` variable.
+- `utime` returns the system clock as microseconds (a double-cell integer), used to seed the RNG at startup.
+
+These are Gforth-specific and not portable to other Forth systems without modification. This is documented in the source and noted here so it is not mistaken for standard ANS Forth. On most Linux systems Gforth is available via the package manager (`apt install gforth` on Debian/Ubuntu derivatives).
 
 
 ### Rust
@@ -160,5 +191,5 @@ I have chapters in [one of my books](https://www.amazon.com/Ubuntu-Linux-Unleash
 
 ### Future ideas/plans
 
-Dunno. Maybe Kotlin? Erlang? Forth? Perhaps something like Algol or even Pascal? Something else?? Ideas are also welcome, just file an issue.
+Dunno. Maybe Kotlin? Erlang? Perhaps something like Algol or even Pascal? Something else?? Ideas are also welcome, just file an issue.
 

--- a/guessnumber.fth
+++ b/guessnumber.fth
@@ -1,0 +1,192 @@
+\ Guess my number game
+\
+\ -- A Gforth version of a silly game I made on my programmable
+\    calculator when I was bored in math class in 1987, with a couple of
+\    additions like input validation and computer guesses.
+\
+\ Copyright (c) 2007 Matthew Helmke for the old Python 2 version
+\ Copyright (c) 2026 Matthew Helmke for the Gforth version (this one)
+\    with assistance from Claude Code (claude.ai/code)
+\    using the claude-sonnet-4-6 model
+\
+\ To run:
+\   gforth guessnumber.fth
+\
+\ This program is free software; you can redistribute it and/or
+\ modify it under the terms of the GNU General Public License
+\ as published by the Free Software Foundation; either version 2
+\ of the License, or (at your option) any later version.
+\
+\ This program is distributed in the hope that it will be useful,
+\ but WITHOUT ANY WARRANTY; without even the implied warranty of
+\ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+\ GNU General Public License for more details.
+\
+\ You should have received a copy of the GNU General Public License
+\ along with this program; if not, write to the Free Software
+\ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+\ variables - names match the project standard across all language versions
+VARIABLE secretnumber
+VARIABLE userguess
+VARIABLE totalguesses
+VARIABLE lowmax
+VARIABLE highmax
+VARIABLE guessrange
+VARIABLE computerguess
+
+\ raw input buffer before validation, corresponds to userguessunvalidated in other versions
+256 CONSTANT buf-max
+CREATE userguessunvalidated buf-max ALLOT
+VARIABLE uguess-len
+
+\ random.fs provides the random word; utime seeds it from the system clock (both Gforth extensions)
+require random.fs
+
+: init-game ( -- )
+  utime drop seed !
+  rnd drop                          \ advance once: the LCG's first step from a 64-bit timestamp is low-entropy
+  100 random 1 + secretnumber !
+  0 userguess !
+  0 totalguesses !
+  1 lowmax !
+  100 highmax ! ;
+
+\ print a description of the game, with rules, to the screen
+: print-welcome ( -- )
+  cr
+  ." Welcome to Guess My Number!" cr cr
+  ." The computer will select a random whole number between 1 and 100." cr cr
+  ." Your goal is to guess that number. You will get a turn, then a computer" cr
+  ." player will get a turn. Each of you are aware of the other's guesses." cr
+  ." The first one to guess the number correctly will win. Try to guess in" cr
+  ." as few turns as possible." cr cr
+  ." Here we go!" cr cr ;
+
+\ skip leading whitespace in a string
+: skip-spaces ( c-addr u -- c-addr' u' )
+  begin
+    dup 0 > if over c@ bl <= else false then
+  while
+    1 /string
+  repeat ;
+
+\ convert a string to an integer; returns ( n true ) on success, ( 0 false ) on failure
+: parse-integer ( c-addr u -- n flag )
+  skip-spaces
+  dup 0= if 2drop 0 false exit then
+  0. 2swap >number  ( ud c-addr' u' )
+  nip 0=            ( lo hi flag )
+  if drop true else 2drop 0 false then ;
+
+\ read a line into userguessunvalidated and try to parse it as an integer
+: read-user-input ( -- n flag )
+  userguessunvalidated buf-max accept
+  uguess-len !
+  userguessunvalidated uguess-len @ parse-integer ;
+
+\ keep prompting until the user enters a valid whole number between 1 and 100
+: get-valid-userguess ( -- n )
+  begin
+    ." What is your guess? "
+    read-user-input
+    if  ( n )
+      dup 0 > over 101 < and
+      if exit then
+      drop
+      ." Only whole numbers from 1 to 100 are allowed. Your guess is out of range." cr
+      ." Please try again." cr cr
+    else
+      drop
+      ." Only whole numbers from 1 to 100 are allowed." cr
+      ." Please try again." cr cr
+    then
+  again ;
+
+\ handle the user's turn; returns true if the game ends
+: user-turn ( -- done? )
+  get-valid-userguess userguess !
+  1 totalguesses +!
+
+  \ some taunts for silly errors in user guesses
+  userguess @ lowmax @ < if
+    ." That guess was lower than a previous guess that was too low. Pay attention!" cr
+  then
+  userguess @ highmax @ > if
+    ." Wake up! That guess was higher than an earlier guess that was too high." cr
+  then
+
+  \ evaluate the user guess
+  userguess @ secretnumber @ > if
+    ." Your guess is too high." cr cr
+    userguess @ highmax @ <= if userguess @ 1 - highmax ! then
+  then
+  userguess @ secretnumber @ < if
+    ." Your guess is too low." cr cr
+    userguess @ lowmax @ >= if userguess @ 1 + lowmax ! then
+  then
+  userguess @ secretnumber @ = if
+    cr
+    ." *********************************************" cr
+    ."    Your guess is correct! Congratulations!" cr
+    ."    It took " totalguesses @ . ." total guesses." cr
+    ." *********************************************" cr cr
+    true exit
+  then
+  false ;
+
+\ handle the computer's turn; returns true if the game ends
+: computer-turn ( -- done? )
+  \ this is to prevent trying to generate a random number from a range of 0
+  highmax @ lowmax @ - guessrange !
+  guessrange @ 1 < if 1 guessrange ! then
+
+  \ the computer's guess uses a binary-search midpoint within current bounds
+  lowmax @ highmax @ + 2 / computerguess !
+  1 totalguesses +!
+
+  computerguess @ secretnumber @ > if
+    ." The computer guessed " computerguess @ . ." and that was too high." cr
+    ." Please try again." cr cr
+    computerguess @ highmax @ <= if computerguess @ 1 - highmax ! then
+  then
+  computerguess @ secretnumber @ < if
+    ." The computer guessed " computerguess @ . ." and that was too low." cr
+    ." Please try again." cr cr
+    computerguess @ lowmax @ >= if computerguess @ 1 + lowmax ! then
+  then
+  computerguess @ secretnumber @ = if
+    ." **********************************************" cr
+    ."    The computer's guess of " computerguess @ . ." is correct!" cr
+    ."    It took " totalguesses @ . ." total guesses." cr
+    ." **********************************************" cr cr
+    true exit
+  then
+  false ;
+
+\ these taunts are just for amusement and to keep the game from being too terribly long
+: check-taunts ( -- )
+  totalguesses @ 8  = if cr ." This is a hard number, isn't it?" cr cr then
+  totalguesses @ 12 = if cr ." Wow! You are really bad at this." cr cr then ;
+
+: check-game-over ( -- done? )
+  totalguesses @ 16 >= if
+    cr ." You're taking too long, I can't handle it any more." cr cr
+    ." G A M E   O V E R" cr cr
+    true exit
+  then
+  false ;
+
+\ the main bit
+: play-game ( -- )
+  init-game
+  print-welcome
+  begin
+    user-turn     if exit then
+    computer-turn if exit then
+    check-taunts
+    check-game-over if exit then
+  again ;
+
+play-game
+bye


### PR DESCRIPTION
Add Gforth (Forth) implementation and document variable naming convention

- Add guessnumber.fth: a complete Gforth implementation following the behavioral contract, using the project-standard variable names
- Add variable naming convention section to README
- Add Forth to the language list and Extra notes (RNG quirks documented)
- Add Claude Code to the AI platforms list
- Remove Forth from the future ideas list